### PR TITLE
fix custom-ui-injections, make directory-separator os independent.

### DIFF
--- a/DotNetifyLib.Pulse/PulseMiddleware.cs
+++ b/DotNetifyLib.Pulse/PulseMiddleware.cs
@@ -20,7 +20,7 @@ namespace DotNetify.Pulse
 {
    internal class PulseMiddleware
    {
-      private static readonly string DEFAULT_UI_PATH = $"{Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)}\\pulse-ui";
+      private static readonly string DEFAULT_UI_PATH = $"{Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)}{Path.DirectorySeparatorChar}pulse-ui";
 
       private readonly RequestDelegate _next;
       private readonly PulseConfiguration _config;
@@ -47,7 +47,7 @@ namespace DotNetify.Pulse
 
             await httpContext.Response.WriteAsync(index
                .Replace("/*style*/", style)
-               .Replace("/*style_ext*/", style)
+               .Replace("/*style_ext*/", styleExt)
                .Replace("<!--script-->", script)
                .Replace("<!--section-->", section)
                .Replace("<!--section_ext-->", sectionExt)
@@ -59,8 +59,10 @@ namespace DotNetify.Pulse
 
       private string ReadFile(string fileName, string path, string defaultPath)
       {
-         string filePath = $"{path}\\{fileName}";
-         string defaultFilePath = $"{defaultPath}\\{fileName}";
+         char directorySeparatorChar  = Path.DirectorySeparatorChar;
+         string separatorWithFileName = $"{directorySeparatorChar}{fileName}";
+         string filePath              = path + separatorWithFileName;
+         string defaultFilePath       = defaultPath + separatorWithFileName;
 
          string validPath = File.Exists(filePath) ? filePath : File.Exists(defaultFilePath) ? defaultFilePath : null;
          if (validPath == null)

--- a/DotNetifyLib.Pulse/pulse-ui/index.html
+++ b/DotNetifyLib.Pulse/pulse-ui/index.html
@@ -10,6 +10,7 @@
 
     <style>
         /*style*/
+        /*style_ext*/
     </style>
     <!-- Polyfills for IE 11 -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js"></script>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Adds an endpoint to any .NET Core service that opens a customizable web view to 
 
 ##### 1. Install the nuget package:
 ```
-dotnet add package DoNetify.Pulse
+dotnet add package DotNetify.Pulse
 ```
 
 ##### 2. Configure the services and the pipeline in `Startup.cs`:


### PR DESCRIPTION
Hi @dsuryd 

I've just tried to use your excellent pulse-library in my project. Unfortunately, it didn't work, because I'm running in a linux-docker-container, that cannot handle the windows-directory-separator.

I've fixed it for my project and wanted to thank you for your work by contributing this improvement along with some small fixes for obvious oversights that I've encountered along the way...

I hope this PR is to your liking, otherwise just let me know... ;-)

greetings from Switzerland!
Mumrich